### PR TITLE
Add GitHub release step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,21 @@ jobs:
         name: release-package
         path: "dist/lens-for-google-calendar-v*.zip"
         retention-days: 90
+    
+    - name: Extract version
+      if: github.ref == 'refs/heads/main' && matrix.node-version == '20.x'
+      id: version
+      run: |
+        VERSION=$(node -e "console.log(require('./manifest.json').version)")
+        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+    
+    - name: Create GitHub Release
+      if: github.ref == 'refs/heads/main' && matrix.node-version == '20.x'
+      uses: softprops/action-gh-release@v1
+      with:
+        files: dist/lens-for-google-calendar-v*.zip
+        tag_name: v${{ steps.version.outputs.VERSION }}
+        draft: false
+        prerelease: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Integrate a step in the CI workflow to extract the version from the manifest and create a GitHub release upon merging to the main branch.